### PR TITLE
Upgrade OpenCV 4.3.0 & Add OpenCV CUDA DNN support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The advantage of packaging is that you can use the resulting package file to ins
 * OpenCV 4.1.1
 * Packaging Option ( Builds package by default; --no_package does not build package)
 
-<b>June 2020, Upgrade OpenCV 4.3.1 & Add cmake cuDNN, DNN_CUDA Support</b>
+<b>June 2020, Upgrade OpenCV 4.3.0 & Add cmake cuDNN, DNN_CUDA Support</b>
 
 * Jetson Nano
 * L4T 32.2.1/JetPack 4.2.2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Script for building OpenCV 4 on the NVIDIA Jetson Nano Developer Kit
 Building for:
 * Jetson Nano
 * L4T 32.2.1/JetPack 4.2.2
-* OpenCV 4.1.1
+* OpenCV 4.3.0
 * Packaging Option ( Builds package by default; --no_package does not build package)
 
 <em><b>Note: </b>The script does not check to see which version of L4T is running before building, understand the script may only work with the stated versions.</em>
@@ -36,11 +36,13 @@ Note that if you are building for Python, you most definitely will benefit from 
 OpenCV is a very rich environment, with many different options available. Check the script to make sure that the options you need are included/excluded. By default, the buildOpenCV.sh script selects these major options:
 
 * CUDA on
+* OpenCV DNN for CUDA, 
 * GStreamer
 * V4L - (Video for Linux)
 * QT - (<em>No gtk support built in</em>)
 * Python 2 bindings
 * Python 3 bindings
+* Pkg config on
 
 ## Packaging
 By default, the build will create a OpenCV package. The package file will be found in:
@@ -55,4 +57,11 @@ The advantage of packaging is that you can use the resulting package file to ins
 * Jetson Nano
 * L4T 32.2.1/JetPack 4.2.2
 * OpenCV 4.1.1
+* Packaging Option ( Builds package by default; --no_package does not build package)
+
+<b>June 2020, Upgrade OpenCV 4.3.1 & Add cmake cuDNN, DNN_CUDA Support</b>
+
+* Jetson Nano
+* L4T 32.2.1/JetPack 4.2.2
+* OpenCV 4.3.0
 * Packaging Option ( Builds package by default; --no_package does not build package)

--- a/buildOpenCV.sh
+++ b/buildOpenCV.sh
@@ -2,7 +2,7 @@
 # License: MIT. See license file in root directory
 # Copyright(c) JetsonHacks (2017-2019)
 
-OPENCV_VERSION=4.1.1
+OPENCV_VERSION=4.3.0
 # Jetson Nano
 ARCH_BIN=5.3
 INSTALL_DIR=/usr/local
@@ -152,6 +152,8 @@ echo $PWD
 time cmake -D CMAKE_BUILD_TYPE=RELEASE \
       -D CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} \
       -D WITH_CUDA=ON \
+      -D WITH_CUDNN=ON \
+      -D OPENCV_DNN_CUDA=ON \
       -D CUDA_ARCH_BIN=${ARCH_BIN} \
       -D CUDA_ARCH_PTX="" \
       -D ENABLE_FAST_MATH=ON \
@@ -167,6 +169,7 @@ time cmake -D CMAKE_BUILD_TYPE=RELEASE \
       -D BUILD_opencv_python3=ON \
       -D BUILD_TESTS=OFF \
       -D BUILD_PERF_TESTS=OFF \
+      -D OPENCV_GENERATE_PKGCONFIG=ON \
       -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules \
       $"PACKAGE_OPENCV" \
       ../


### PR DESCRIPTION

**Description**
<!-- Add your description below. -->
I upgrade OpenCV version from 4.1.1 to 4.3.0, and adding OpenCV CUDA dnn dependencies in cmake command.
Moverover, I also added `OPENCV_GENERATE_PKGCONFIG` flag.


