### PR TITLE
Fix Deb Package Creation

### DIFF
--- a/buildOpenCV.sh
+++ b/buildOpenCV.sh
@@ -168,7 +168,7 @@ time cmake -D CMAKE_BUILD_TYPE=RELEASE \
       -D BUILD_TESTS=OFF \
       -D BUILD_PERF_TESTS=OFF \
       -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules \
-      $"PACKAGE_OPENCV" \
+      ${PACKAGE_OPENCV} \
       ../
 
 


### PR DESCRIPTION
Fixed the PACKAGE_OPENCV parameter substitution for the CMAKE command line.

**Description**
Parameter expansion of the variable PACKAGE_OPENCV was not handled properly when generating the CMake command line preventing Debian packages from being generated.

